### PR TITLE
Add back <google-drive> element

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "google-apis": "GoogleWebComponents/google-apis#^1.0.0",
+    "google-drive": "GoogleWebComponents/google-drive#^1.0.1",
     "google-feeds": "GoogleWebComponents/google-feeds#^1.0.0",
     "google-map": "GoogleWebComponents/google-map#^1.0.0",
     "google-signin": "GoogleWebComponents/google-signin#^1.0.0",

--- a/google-web-components.html
+++ b/google-web-components.html
@@ -3,7 +3,7 @@
 <link rel="import" href="../google-calendar/google-calendar.html">
 <link rel="import" href="../google-castable-video/google-castable-video.html">
 <link rel="import" href="../google-chart/google-chart.html">
-<!-- <link rel="import" href="../google-drive/google-drive.html"> -->
+<link rel="import" href="../google-drive/google-drive.html">
 <link rel="import" href="../google-feeds/google-feeds.html">
 <link rel="import" href="../google-hangout-button/google-hangout-button.html">
 <link rel="import" href="../google-map/google-map.html">


### PR DESCRIPTION
[`<google-drive>`](https://github.com/GoogleWebComponents/google-drive) was removed by @mbleigh on 15.05.2015 in 01f5b6166c40793b582e393eb37b2ac1b9dbdad4 commit, because it was not Polymer 0.9 compatible. Currently it is Polymer 1.x compatible. So it can be added back.